### PR TITLE
Fixed incorrect grammar

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Many thanks for your contribution, we truly appreciate it. We will appreciate it even more, if you make sure that you can say "YES" to each point in this short checklist:
 
-  - You made a small amount of changes (less than 100 lines, less than 10 files)
+  - You made a small number of changes (less than 100 lines, less than 10 files)
   - You made changes related to only one bug (create separate PRs for separate problems)
   - You are ready to defend your changes (there will be a code review)
   - You don't touch what you don't understand


### PR DESCRIPTION
I suggest to change word `amount` to `number` in the PR template line 4:

>   - You made a small amount of changes (less than 100 lines, less than 10 files)

This is the reasoning:

![image](https://user-images.githubusercontent.com/7301634/38078899-c2d62b8e-334e-11e8-8af5-47971e1aa3b0.png)


This is the overall checklist for the PR:
  - [x] You made a small amount of changes (less than 100 lines, less than 10 files)
  - [x] You made changes related to only one bug (create separate PRs for separate problems)
  - [x] You are ready to defend your changes (there will be a code review)
  - [x] You don't touch what you don't understand
  - [n/a] You ran the build locally and it passed
