### PR TITLE
Python code refactored according to PEP8, Linter workflow added

### DIFF
--- a/.github/workflows/python-flake8-lint.yml
+++ b/.github/workflows/python-flake8-lint.yml
@@ -1,0 +1,26 @@
+name: Python-Flake8-Linter
+
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  flake8:
+    name: Flake8
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: pip install flake8
+      - name: Run Flake8
+        run: |
+          flake8 --max-line-length=120 .

--- a/requs_pygment/requs_pygment.py
+++ b/requs_pygment/requs_pygment.py
@@ -4,6 +4,7 @@ from pygments.lexer import RegexLexer
 from pygments.token import Punctuation, Text, Keyword, Name, String, Operator
 from pygments.util import shebang_matches
 
+
 class RequsLexer(RegexLexer):
     name = 'requs'
     aliases = ['requs']
@@ -11,14 +12,16 @@ class RequsLexer(RegexLexer):
         'root': [
             (r'"""[\n.]+"""', Text),
             (r'"[^"]+"', String),
-            (r'\b(includes|requires|contains|actor|needs|means|using|of|with|when|must|is|a|(T|t)he|as|where|and)\b', Keyword),
+            (
+                r'\b(includes|requires|contains|actor|needs|means|using|of|with|when|must|is|a|(T|t)he|as|where|and)\b',
+                Keyword,
+            ),
             (r'\b(creates|reads|updates|deletes|Fail\s+since)\b', Operator),
             (r'\b[A-Z]+\b', Name),
             (r'\b([A-Z][a-z0-9]*)+\b', Name),
             (r'[,;:]', Punctuation),
         ],
     }
+
     def analyse_text(text):
         return shebang_matches(text, r'requs')
-
-

--- a/requs_pygment/setup.py
+++ b/requs_pygment/setup.py
@@ -1,18 +1,19 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
+
 setup(
-    name = 'requs_pygment',
-    version = '0.1',
-    packages = find_packages(),
-    install_requires = ['pygments'],
-    py_modules = ['requs_pygment'],
-    author = 'Yegor Bugayenko',
-    author_email = 'yegor256@gmail.com',
-    description = 'Requs Highlighting Pygment',
-    license = 'BSD',
-    keywords = 'requs',
-    url = 'http://www.requs.org/',
-    entry_points = {
+    name='requs_pygment',
+    version='0.1',
+    packages=find_packages(),
+    install_requires=['pygments'],
+    py_modules=['requs_pygment'],
+    author='Yegor Bugayenko',
+    author_email='yegor256@gmail.com',
+    description='Requs Highlighting Pygment',
+    license='BSD',
+    keywords='requs',
+    url='http://www.requs.org/',
+    entry_points={
         'pygments.lexers': [
             'requs = requs_pygment:RequsLexer'
         ]


### PR DESCRIPTION
I found, that this repository contains Python scripts.
In order to improve code support inside the repository, Python linter has been added as the new GitHub Actions workflow.
For the convenience of working inside the Jetbrains IDE set, an additional flag --max-line-length=120 was added, since this value is the default for the built-in PyCharm linter.
Also, existing code was refactored, to prevent linter warnings on build.
@yegor256 check please