### PR TITLE
fix: normalize CRLF in static analysis input (#66)

### DIFF
--- a/requs-core/src/main/java/org/requs/facet/sa/Rules.java
+++ b/requs-core/src/main/java/org/requs/facet/sa/Rules.java
@@ -53,13 +53,7 @@ public final class Rules implements XeFacet {
             ),
             new LineRule.Wrap(
                 new RegexRule(
-                    "\r",
-                    "don't use Windows line-endings"
-                )
-            ),
-            new LineRule.Wrap(
-                new RegexRule(
-                    ",[^$ \n\r]",
+                    ",[^$ \n]",
                     "always use space after comma"
                 )
             ),
@@ -76,7 +70,8 @@ public final class Rules implements XeFacet {
         if (spec.nodes("/spec/input[.!='']").isEmpty()) {
             input = "";
         } else {
-            input = spec.xpath("/spec/input/text()").get(0);
+            input = spec.xpath("/spec/input/text()").get(0)
+                .replace("\r\n", "\n").replace('\r', '\n');
         }
         final Directives dirs = new Directives().xpath("/spec").addIf("errors");
         for (final Rule rule : rules) {

--- a/requs-core/src/test/java/org/requs/facet/sa/RulesTest.java
+++ b/requs-core/src/test/java/org/requs/facet/sa/RulesTest.java
@@ -38,4 +38,24 @@ final class RulesTest {
         );
     }
 
+    @Test
+    void toleratesWindowsLineEndings() throws IOException {
+        MatcherAssert.assertThat(
+            "CRLF input should not produce any rule violations",
+            new XeFacet.Wrap(new Rules()).touch(
+                new XMLDocument(
+                    StringUtils.join(
+                        "<spec><input>",
+                        "User is a &quot;human being&quot;.&#13;\n",
+                        "Order is a &quot;customer request&quot;.&#13;\n",
+                        "</input></spec>"
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/spec/errors[count(error)=0]"
+            )
+        );
+    }
+
 }


### PR DESCRIPTION
The static analysis facet in `requs-core` treated every carriage return as a violation ("don't use Windows line-endings"), which made the compiler unusable for contributors whose Git client checks out `.req` files with CRLF endings. The behaviour traces to a `RegexRule` on `\r` declared in `Rules.touch`. Issue #66 reports the same symptom on Windows.

Input is now normalised in `Rules.touch`: `\r\n` collapses to `\n` and any stray `\r` becomes `\n` before the line rules iterate. The dedicated CRLF rule is removed because it can no longer fire, and the `,[^$ \n\r]` pattern in the "space after comma" rule loses its now-unreachable `\r` class. A new `toleratesWindowsLineEndings` case in `RulesTest` feeds CRLF-terminated lines through the facet and asserts that no errors are produced.

Ran `mvn -B -pl requs-core test -Dtest=RulesTest,LineRuleTest,RegexRuleTest,CascadingRuleTest,IndentationRuleTest`: 9 tests, all green, including the new case.

Closes #66
